### PR TITLE
Added bulk group member addition support

### DIFF
--- a/SeafClient/Requests/Groups/BulkAddGroupMemberRequest.cs
+++ b/SeafClient/Requests/Groups/BulkAddGroupMemberRequest.cs
@@ -1,0 +1,67 @@
+﻿using SeafClient.Requests.UserAccountInfo;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeafClient.Requests.Groups
+{
+    public class BulkAddGroupMemberRequest : SessionRequest<BulkAddGroupMemberResponse>
+    {
+        public override string CommandUri => String.Format("api/v2.1/groups/{0:d}/members/bulk/", GroupId);
+
+        public override HttpAccessMethod HttpAccessMethod => HttpAccessMethod.Post;
+
+        public int GroupId;
+
+        public IEnumerable<string> UserNames;
+        public string Emails;
+
+        public BulkAddGroupMemberRequest(string authToken, int groupId, IEnumerable<string> userNames) : base(authToken)
+        {
+            GroupId = groupId;
+            UserNames = userNames;
+            Emails = string.Join(",", userNames);
+        }
+
+        public override IEnumerable<KeyValuePair<string, string>> GetBodyParameters()
+        {
+            yield return new KeyValuePair<string, string>("emails", Emails);
+        }
+
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class BulkAddGroupMemberResponse
+    {
+        public FailedAddGroupMember[] Failed { get; set; }
+        public SuccessAddGroupMember[] Success { get; set; }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class FailedAddGroupMember
+    {
+        public string error_msg { get; set; }
+        public string email { get; set; }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class SuccessAddGroupMember
+    {
+        public string login_id { get; set; }
+        public string name { get; set; }
+        public string avatar_url { get; set; }
+        public bool is_admin { get; set; }
+        public string contact_email { get; set; }
+        public string email { get; set; }
+    }
+
+}

--- a/SeafClient/SeafClient.csproj
+++ b/SeafClient/SeafClient.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Requests\Files\GetFileDetailRequest.cs" />
     <Compile Include="Requests\Groups\AddGroupMemberRequest.cs" />
     <Compile Include="Requests\Groups\AddGroupRequest.cs" />
+    <Compile Include="Requests\Groups\BulkAddGroupMemberRequest.cs" />
     <Compile Include="Requests\Groups\DeleteGroupRequest.cs" />
     <Compile Include="Requests\Groups\ListGroupMembersRequest.cs" />
     <Compile Include="Requests\Groups\ListGroupsRequest.cs" />
@@ -132,9 +133,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Visual Studio 2017\Projects\packages\Newtonsoft.Json.12.0.1\lib\portable-net45+win8+wp8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/SeafClient/SeafClient.csproj
+++ b/SeafClient/SeafClient.csproj
@@ -133,8 +133,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Visual Studio 2017\Projects\packages\Newtonsoft.Json.12.0.1\lib\portable-net45+win8+wp8+wpa81\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/SeafClient/packages.config
+++ b/SeafClient/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="portable45-net45+win8+wpa81" />
-</packages>

--- a/SeafClient/packages.config
+++ b/SeafClient/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="portable45-net45+win8+wpa81" />
 </packages>


### PR DESCRIPTION
With this new class **BulkAddGroupMemberRequest** you can add multiple users to a group by providing a list of emails. The result will contain arrays of Success and Failed results. Success will report detail on successfully added members and Failed will provide which email matches which error message.

The Server must provide API v. 2.1 in addition to 2.0.